### PR TITLE
Add noise point handling with configurable clustering strategy

### DIFF
--- a/qadst/base.py
+++ b/qadst/base.py
@@ -42,6 +42,7 @@ class BaseClusterer(ABC):
         min_cluster_size: Optional[int] = None,
         min_samples: Optional[int] = None,
         cluster_selection_epsilon: Optional[float] = None,
+        keep_noise: bool = False,
     ):
         """Initialize the clusterer.
 
@@ -53,6 +54,7 @@ class BaseClusterer(ABC):
             min_cluster_size: Minimum size of clusters (if None, auto-calculated)
             min_samples: HDBSCAN min_samples parameter (default: 5)
             cluster_selection_epsilon: HDBSCAN epsilon parameter (default: 0.3)
+            keep_noise: Whether to keep noise points unclustered (default: False)
         """
         self.embedding_model_name = embedding_model_name
         self.llm_model_name = llm_model_name
@@ -62,6 +64,7 @@ class BaseClusterer(ABC):
         self.min_cluster_size = min_cluster_size
         self.min_samples = min_samples
         self.cluster_selection_epsilon = cluster_selection_epsilon
+        self.keep_noise = keep_noise
 
         # Create output directory if it doesn't exist
         os.makedirs(self.output_dir, exist_ok=True)

--- a/qadst/cli.py
+++ b/qadst/cli.py
@@ -107,6 +107,11 @@ def cli():
     default=None,
     help="HDBSCAN cluster_selection_epsilon parameter (default: 0.3)",
 )
+@click.option(
+    "--keep-noise/--cluster-noise",
+    default=False,
+    help="Keep noise points unclustered (default: False, noise points are clustered)",
+)
 def cluster_command(
     output_dir,
     llm_model,
@@ -116,6 +121,7 @@ def cluster_command(
     min_cluster_size,
     min_samples,
     cluster_selection_epsilon,
+    keep_noise,
 ):
     """Cluster QA pairs using HDBSCAN algorithm."""
     logger.info("Starting QA dataset clustering process")
@@ -138,6 +144,7 @@ def cluster_command(
         min_cluster_size=min_cluster_size,
         min_samples=min_samples,
         cluster_selection_epsilon=cluster_selection_epsilon,
+        keep_noise=keep_noise,
     )
 
     logger.info(f"Processing dataset from {input}")


### PR DESCRIPTION
- Introduce `--keep-noise/--cluster-noise` CLI option to control noise point processing
- Implement flexible noise point handling in HDBSCAN clustering
- Add support for preserving or clustering noise points based on user preference
- Update USAGE.md with detailed explanation of noise point handling
- Enhance cluster formatting to support optional noise cluster
- Add comprehensive test cases for noise point handling