### PR TITLE
Implement flexible reporting system for clustering results

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
-# Installation Guide for QA Dataset Clustering Toolkit
+# Installation Guide for qadst
 
-This document provides detailed instructions for installing and setting up the QA Dataset Clustering Toolkit (QADST).
+This document provides detailed instructions for installing and setting up the `qadst` package.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QA Dataset Clustering Toolkit (QADST)
+# QA Dataset Clustering Toolkit (qadst)
 
 [![CI](https://github.com/sergeyklay/qa-dataset-clustering/actions/workflows/ci.yml/badge.svg)](https://github.com/sergeyklay/qa-dataset-clustering/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sergeyklay/qa-dataset-clustering/graph/badge.svg?token=T5d9KTXtqP)](https://codecov.io/gh/sergeyklay/qa-dataset-clustering)

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,6 @@
-# QA Dataset Clustering Toolkit (QADST) - Usage Guide
+# Usage Guide
 
-This document provides detailed usage instructions for the QA Dataset Clustering Toolkit (QADST).
+This document provides detailed usage instructions for the `qadst` package.
 
 ## Usage
 
@@ -356,3 +356,86 @@ If you need to regenerate embeddings (e.g., after updating to a new version of a
 # Remove all embedding cache files
 rm output/embeddings_*.npy
 ```
+
+### Customizing Report Output
+
+The toolkit provides a flexible reporting system that allows you to control how clustering results are presented. By default, two reporters are enabled:
+
+1. **CSV Reporter**: Generates a CSV file with detailed metrics for each cluster
+2. **Console Reporter**: Displays summary information and top clusters in the console
+
+You can customize which reporters are enabled using the `--reporters` option:
+
+```bash
+# Use only the CSV reporter
+qadst benchmark --clusters output/qa_clusters.json --qa-pairs data/qa_pairs.csv --reporters csv
+
+# Use only the console reporter
+qadst benchmark --clusters output/qa_clusters.json --qa-pairs data/qa_pairs.csv --reporters console
+
+# Use both reporters (default)
+qadst benchmark --clusters output/qa_clusters.json --qa-pairs data/qa_pairs.csv --reporters csv,console
+```
+
+#### CSV Reporter Output
+
+The CSV reporter generates a file named `cluster_quality_report.csv` in the output directory with the following columns:
+
+- **Cluster_ID**: Unique identifier for each cluster
+- **Num_QA_Pairs**: Number of question-answer pairs in the cluster
+- **Avg_Similarity**: Average pairwise similarity between questions in the cluster
+- **Coherence_Score**: Semantic coherence score for the cluster (higher is better)
+- **Topic_Label**: Descriptive label for the cluster content
+
+The file also includes a summary row with global metrics.
+
+#### Console Reporter Output
+
+The console reporter displays a formatted table view with:
+
+1. **Summary Section**:
+   - Total number of QA pairs in the dataset
+   - Path to the clusters JSON file
+   - Global metrics (Noise Ratio, Davies-Bouldin Index, Calinski-Harabasz Index, Silhouette Score)
+
+2. **Top Clusters Table**:
+   - Displays the top 5 clusters by size in a formatted table
+   - Columns include Cluster ID, Size, Coherence, and Topic
+   - Topics are truncated if they're too long to fit in the display
+
+Example output:
+```
+--------------------------------------------------------------------------------
+|                           CLUSTER ANALYSIS SUMMARY                           |
+--------------------------------------------------------------------------------
+Total QA pairs: 5175
+Clusters JSON: output/qa_clusters.json
+
+Global Metrics:
+  Noise Ratio: 0.00
+  Davies-Bouldin Index: 3.95
+  Calinski-Harabasz Index: 35.91
+  Silhouette Score: 0.12
+
+--------------------------------------------------------------------------------
+|                            TOP 5 CLUSTERS BY SIZE                            |
+--------------------------------------------------------------------------------
+| Cluster ID | Size         | Coherence    | Topic                             |
+--------------------------------------------------------------------------------
+| 1          | 582          | 0.37         | API Endpoint Behavior             |
+| 2          | 537          | 0.49         | Digital Document Workflows        |
+| 17         | 206          | 0.14         | Customer Trust Insights           |
+| 6          | 168          | 0.43         | API Integration Guidelines        |
+| 41         | 158          | 0.52         | Feature-Specific Integrations     |
+--------------------------------------------------------------------------------
+```
+
+#### Extending the Reporting System
+
+The reporting system is designed to be extensible. Developers can create custom reporters by:
+
+1. Implementing a class that inherits from `BaseReporter`
+2. Implementing the `generate_report` method
+3. Registering the reporter with the `ReporterRegistry`
+
+This allows for additional output formats such as HTML, JSON, or integration with other systems.

--- a/qadst/reporters/__init__.py
+++ b/qadst/reporters/__init__.py
@@ -1,0 +1,18 @@
+"""Reporting functionality for QA dataset clustering results.
+
+This module provides various reporters for outputting clustering results and metrics
+in different formats, such as CSV files, console output, and potentially others.
+"""
+
+from .base import BaseReporter, ReportData
+from .console import ConsoleReporter
+from .csv import CSVReporter
+from .registry import ReporterRegistry
+
+__all__ = [
+    "BaseReporter",
+    "ReportData",
+    "ConsoleReporter",
+    "CSVReporter",
+    "ReporterRegistry",
+]

--- a/qadst/reporters/base.py
+++ b/qadst/reporters/base.py
@@ -1,0 +1,57 @@
+"""Base reporter class for QA dataset clustering results."""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ReportData:
+    """Data structure for cluster report data.
+
+    This class holds all the data needed for generating reports in various formats.
+
+    Attributes:
+        report_df: DataFrame containing cluster metrics and information
+        clusters_json_path: Path to the clusters JSON file
+        output_dir: Directory where reports should be saved
+        summary_metrics: Dictionary of global metrics
+        top_clusters: DataFrame containing the top N clusters by size
+    """
+
+    report_df: pd.DataFrame
+    clusters_json_path: str
+    output_dir: str
+    summary_metrics: Dict[str, Any]
+    top_clusters: pd.DataFrame
+
+
+class BaseReporter(ABC):
+    """Base class for all reporters.
+
+    This abstract class defines the interface that all reporters must implement.
+    Reporters are responsible for outputting clustering results and metrics in
+    various formats (CSV, console, etc.).
+    """
+
+    def __init__(self, output_dir: str):
+        """Initialize the reporter.
+
+        Args:
+            output_dir: Directory where reports should be saved
+        """
+        self.output_dir = output_dir
+
+    @abstractmethod
+    def generate_report(self, data: ReportData) -> None:
+        """Generate and output the report.
+
+        Args:
+            data: Report data to be output
+        """
+        pass

--- a/qadst/reporters/console.py
+++ b/qadst/reporters/console.py
@@ -115,8 +115,9 @@ class ConsoleReporter(BaseReporter):
             topic = row["Topic_Label"]
 
             # Truncate topic if too long
-            if len(topic) > col_widths[3] - 3:
-                topic = topic[: col_widths[3] - 6] + "..."
+            max_topic_length = col_widths[3]
+            if len(topic) > max_topic_length:
+                topic = topic[: max_topic_length - 3] + "..."
 
             print(self._format_row([cluster_id, size, coherence, topic], col_widths))
 

--- a/qadst/reporters/console.py
+++ b/qadst/reporters/console.py
@@ -1,0 +1,124 @@
+"""Console reporter for QA dataset clustering results."""
+
+import logging
+from typing import List, Optional
+
+from .base import BaseReporter, ReportData
+
+logger = logging.getLogger(__name__)
+
+
+class ConsoleReporter(BaseReporter):
+    """Reporter that outputs cluster metrics to the console.
+
+    This reporter prints summary information and details about the top clusters
+    to the console using direct print statements with a simple table format.
+    """
+
+    def __init__(self, output_dir: str, top_n: int = 5):
+        """Initialize the console reporter.
+
+        Args:
+            output_dir: Directory where reports are saved (not used directly)
+            top_n: Number of top clusters to display
+        """
+        super().__init__(output_dir)
+        self.top_n = top_n
+        self.table_width = 80
+
+    def _print_separator(self, width: Optional[int] = None) -> None:
+        """Print a separator line.
+
+        Args:
+            width: Width of the separator line
+        """
+        if width is None:
+            width = self.table_width
+        print("-" * width)
+
+    def _print_header(self, title: str, width: Optional[int] = None) -> None:
+        """Print a header with a title.
+
+        Args:
+            title: Title to display
+            width: Width of the header
+        """
+        if width is None:
+            width = self.table_width
+        self._print_separator(width)
+        print(f"| {title.center(width - 4)} |")
+        self._print_separator(width)
+
+    def _format_row(self, columns: List[str], widths: List[int]) -> str:
+        """Format a row with columns of specified widths.
+
+        Args:
+            columns: Column values
+            widths: Column widths
+
+        Returns:
+            Formatted row string
+        """
+        row = "| "
+        for i, col in enumerate(columns):
+            row += f"{str(col):<{widths[i]}} | "
+        return row.rstrip()
+
+    def generate_report(self, data: ReportData) -> None:
+        """Generate a console report with cluster metrics.
+
+        Prints summary information and details about the top clusters to the console
+        using a simple table format.
+
+        Args:
+            data: Report data to be output
+        """
+        # Define column widths for consistent formatting
+        col_widths = [10, 12, 12, 40]
+        # Calculate total table width including borders and padding
+        self.table_width = sum(col_widths) + (len(col_widths) * 3) + 1
+
+        # Print summary information
+        summary_row = data.report_df.iloc[-1]
+
+        self._print_header("CLUSTER ANALYSIS SUMMARY")
+        print(f"Total QA pairs: {summary_row['Num_QA_Pairs']}")
+        print(f"Clusters JSON: {data.clusters_json_path}")
+
+        # Format metrics string
+        metrics = data.summary_metrics
+        print("\nGlobal Metrics:")
+        print(f"  Noise Ratio: {metrics.get('noise_ratio', 'N/A'):.2f}")
+        print(
+            f"  Davies-Bouldin Index: {metrics.get('davies_bouldin_score', 'N/A'):.2f}"
+        )
+        ch_score = metrics.get("calinski_harabasz_score", "N/A")
+        print(f"  Calinski-Harabasz Index: {ch_score:.2f}")
+        if "silhouette_score" in metrics:
+            print(f"  Silhouette Score: {metrics.get('silhouette_score', 'N/A'):.2f}")
+
+        # Print information about top clusters
+        self._print_header(f"TOP {self.top_n} CLUSTERS BY SIZE")
+
+        # Print table header
+        header = self._format_row(
+            ["Cluster ID", "Size", "Coherence", "Topic"], col_widths
+        )
+        print(header)
+        self._print_separator()
+
+        # Print table rows
+        for _, row in data.top_clusters.iterrows():
+            cluster_id = row["Cluster_ID"]
+            size = row["Num_QA_Pairs"]
+            coherence = f"{row['Coherence_Score']:.2f}"
+            topic = row["Topic_Label"]
+
+            # Truncate topic if too long
+            if len(topic) > col_widths[3] - 3:
+                topic = topic[: col_widths[3] - 6] + "..."
+
+            print(self._format_row([cluster_id, size, coherence, topic], col_widths))
+
+        self._print_separator()
+        print()

--- a/qadst/reporters/csv.py
+++ b/qadst/reporters/csv.py
@@ -1,0 +1,39 @@
+"""CSV reporter for QA dataset clustering results."""
+
+import logging
+from pathlib import Path
+
+from .base import BaseReporter, ReportData
+
+logger = logging.getLogger(__name__)
+
+
+class CSVReporter(BaseReporter):
+    """Reporter that outputs cluster metrics to a CSV file.
+
+    This reporter generates a CSV file containing detailed information about
+    each cluster, including size, coherence scores, and topic labels.
+    """
+
+    def __init__(self, output_dir: str, filename: str = "cluster_quality_report.csv"):
+        """Initialize the CSV reporter.
+
+        Args:
+            output_dir: Directory where the CSV file should be saved
+            filename: Name of the CSV file to create
+        """
+        super().__init__(output_dir)
+        self.filename = filename
+
+    def generate_report(self, data: ReportData) -> None:
+        """Generate a CSV report with cluster metrics.
+
+        Saves a CSV file containing detailed information about each cluster,
+        including a summary row with global metrics.
+
+        Args:
+            data: Report data to be output
+        """
+        output_path = Path(self.output_dir) / self.filename
+        data.report_df.to_csv(output_path, index=False)
+        logger.debug(f"CSV report saved to: {output_path}")

--- a/qadst/reporters/registry.py
+++ b/qadst/reporters/registry.py
@@ -1,0 +1,70 @@
+"""Registry for managing multiple reporters."""
+
+import logging
+from typing import Dict, List
+
+from .base import BaseReporter, ReportData
+
+logger = logging.getLogger(__name__)
+
+
+class ReporterRegistry:
+    """Registry for managing multiple reporters.
+
+    This class maintains a collection of reporters and provides methods to
+    register, enable, disable, and use them for generating reports.
+    """
+
+    def __init__(self):
+        """Initialize the reporter registry."""
+        self.reporters: Dict[str, BaseReporter] = {}
+        self.enabled_reporters: List[str] = []
+
+    def register(self, name: str, reporter: BaseReporter, enabled: bool = True) -> None:
+        """Register a reporter with the registry.
+
+        Args:
+            name: Unique name for the reporter
+            reporter: Reporter instance
+            enabled: Whether the reporter should be enabled by default
+        """
+        self.reporters[name] = reporter
+        if enabled and name not in self.enabled_reporters:
+            self.enabled_reporters.append(name)
+        logger.debug(f"Registered reporter: {name} (enabled: {enabled})")
+
+    def enable(self, name: str) -> None:
+        """Enable a reporter.
+
+        Args:
+            name: Name of the reporter to enable
+        """
+        if name in self.reporters and name not in self.enabled_reporters:
+            self.enabled_reporters.append(name)
+            logger.debug(f"Enabled reporter: {name}")
+
+    def disable(self, name: str) -> None:
+        """Disable a reporter.
+
+        Args:
+            name: Name of the reporter to disable
+        """
+        if name in self.enabled_reporters:
+            self.enabled_reporters.remove(name)
+            logger.debug(f"Disabled reporter: {name}")
+
+    def generate_reports(self, data: ReportData) -> None:
+        """Generate reports using all enabled reporters.
+
+        Args:
+            data: Report data to be output
+        """
+        for name in self.enabled_reporters:
+            if name in self.reporters:
+                try:
+                    self.reporters[name].generate_report(data)
+                    logger.debug(f"Generated report using: {name}")
+                except Exception as e:
+                    logger.error(f"Error generating report with {name}: {e}")
+            else:
+                logger.warning(f"Reporter {name} is enabled but not registered")

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -1,0 +1,171 @@
+"""Tests for the reporters module."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from qadst.reporters import (
+    ConsoleReporter,
+    CSVReporter,
+    ReportData,
+    ReporterRegistry,
+)
+
+
+class TestCSVReporter:
+    """Tests for the CSVReporter class."""
+
+    def test_init(self):
+        """Test initialization of CSVReporter."""
+        output_dir = "/tmp/test"
+        reporter = CSVReporter(output_dir)
+        assert reporter.output_dir == output_dir
+        assert reporter.filename == "cluster_quality_report.csv"
+
+    def test_generate_report(self):
+        """Test generate_report method of CSVReporter."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a reporter
+            reporter = CSVReporter(temp_dir)
+
+            # Create test data
+            report_df = pd.DataFrame(
+                {
+                    "Cluster_ID": ["1", "2", "SUMMARY"],
+                    "Num_QA_Pairs": [10, 20, 30],
+                    "Coherence_Score": [0.8, 0.9, 0.0],
+                    "Topic_Label": ["Topic 1", "Topic 2", "Summary"],
+                }
+            )
+            data = ReportData(
+                report_df=report_df,
+                clusters_json_path="test.json",
+                output_dir=temp_dir,
+                summary_metrics={"noise_ratio": 0.1},
+                top_clusters=report_df.iloc[:2],
+            )
+
+            # Generate report
+            reporter.generate_report(data)
+
+            # Check that the file was created
+            output_path = os.path.join(temp_dir, "cluster_quality_report.csv")
+            assert os.path.exists(output_path)
+
+            # Check the content of the file
+            df = pd.read_csv(output_path)
+            assert len(df) == 3
+            assert "Cluster_ID" in df.columns
+            assert "Num_QA_Pairs" in df.columns
+            assert "Coherence_Score" in df.columns
+            assert "Topic_Label" in df.columns
+
+
+class TestConsoleReporter:
+    """Tests for the ConsoleReporter class."""
+
+    def test_init(self):
+        """Test initialization of ConsoleReporter."""
+        output_dir = "/tmp/test"
+        reporter = ConsoleReporter(output_dir)
+        assert reporter.output_dir == output_dir
+        assert reporter.top_n == 5
+
+    def test_generate_report(self):
+        """Test generate_report method of ConsoleReporter."""
+        # Create a reporter
+        reporter = ConsoleReporter("/tmp/test")
+
+        # Create test data
+        report_df = pd.DataFrame(
+            {
+                "Cluster_ID": ["1", "2", "SUMMARY"],
+                "Num_QA_Pairs": [10, 20, 30],
+                "Coherence_Score": [0.8, 0.9, 0.0],
+                "Topic_Label": ["Topic 1", "Topic 2", "Summary"],
+            }
+        )
+        data = ReportData(
+            report_df=report_df,
+            clusters_json_path="test.json",
+            output_dir="/tmp/test",
+            summary_metrics={
+                "noise_ratio": 0.1,
+                "davies_bouldin_score": 1.2,
+                "calinski_harabasz_score": 45.6,
+                "silhouette_score": 0.7,
+            },
+            top_clusters=report_df.iloc[:2],
+        )
+
+        # Generate report with captured stdout
+        with patch("builtins.print") as mock_print:
+            reporter.generate_report(data)
+
+            # Check that print was called with the expected messages
+            assert mock_print.call_count >= 10
+
+            # Check for basic content
+            mock_print.assert_any_call("Total QA pairs: 30")
+            mock_print.assert_any_call("Clusters JSON: test.json")
+            mock_print.assert_any_call("\nGlobal Metrics:")
+
+
+class TestReporterRegistry:
+    """Tests for the ReporterRegistry class."""
+
+    def test_init(self):
+        """Test initialization of ReporterRegistry."""
+        registry = ReporterRegistry()
+        assert registry.reporters == {}
+        assert registry.enabled_reporters == []
+
+    def test_register(self):
+        """Test register method of ReporterRegistry."""
+        registry = ReporterRegistry()
+        reporter = MagicMock()
+        registry.register("test", reporter)
+        assert registry.reporters == {"test": reporter}
+        assert registry.enabled_reporters == ["test"]
+
+    def test_enable_disable(self):
+        """Test enable and disable methods of ReporterRegistry."""
+        registry = ReporterRegistry()
+        reporter = MagicMock()
+        registry.register("test", reporter, enabled=False)
+        assert registry.reporters == {"test": reporter}
+        assert registry.enabled_reporters == []
+
+        registry.enable("test")
+        assert registry.enabled_reporters == ["test"]
+
+        registry.disable("test")
+        assert registry.enabled_reporters == []
+
+    def test_generate_reports(self):
+        """Test generate_reports method of ReporterRegistry."""
+        registry = ReporterRegistry()
+        reporter1 = MagicMock()
+        reporter2 = MagicMock()
+        registry.register("test1", reporter1)
+        registry.register("test2", reporter2)
+
+        data = MagicMock()
+        registry.generate_reports(data)
+
+        reporter1.generate_report.assert_called_once_with(data)
+        reporter2.generate_report.assert_called_once_with(data)
+
+    def test_generate_reports_with_error(self):
+        """Test generate_reports method with an error."""
+        registry = ReporterRegistry()
+        reporter = MagicMock()
+        reporter.generate_report.side_effect = Exception("Test error")
+        registry.register("test", reporter)
+
+        data = MagicMock()
+        with patch("qadst.reporters.registry.logger") as mock_logger:
+            registry.generate_reports(data)
+            mock_logger.error.assert_called_once()


### PR DESCRIPTION
- Add new reporters module with BaseReporter, CSVReporter, and ConsoleReporter
- Create ReporterRegistry to manage and configure multiple report outputs
- Update benchmarker and CLI to support configurable reporting options
- Add `--reporters` CLI option to enable/disable specific reporters
- Enhance USAGE.md with detailed explanation of reporting capabilities
- Implement extensible reporting system with default CSV and console reporters
- Add comprehensive test coverage for new reporting functionality